### PR TITLE
Add Hardcore Ironmen title colours.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -75,6 +75,8 @@ const clueCompleteColor = [4, 143, 6]
 reader.readargs.colors.push(mixColor(clueCompleteColor))
 // Riftsplitter title
 reader.readargs.colors.push(a1lib.mixColor(215, 243, 136))
+// Hardcore Ironmen titles
+reader.readargs.colors.push(a1lib.mixColor(186, 6, 31))
 
 createApp({
     setup() {


### PR DESCRIPTION
Had some issues with using the hardcore ironmen titles (Hardcore Ironman <RSN>, Hardcore Ironwoman <RSN>, <RSN> the Hardcore Ironman, <RSN> the Hardcore Ironwoman) so I just copied the Riftsplitter line and added the RGB code for the hardcore titles.